### PR TITLE
Support converting CJSX

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 module.exports = espresso
 
-var coffeeScript = require('coffee-script')
+var coffeeScript = require('coffee-react')
 var jsCodeShift = require('jscodeshift')
 var coreTransform = require('./transforms/core')
 var jsxTransform = require('./transforms/jsx')

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "espresso": "bin/espresso.sh"
   },
   "dependencies": {
-    "coffee-script": "^1.10.0",
+    "coffee-react": "^4.0.0",
     "jscodeshift": "^0.3.7",
     "nomnom": "^1.8.1"
   },


### PR DESCRIPTION
CoffeeReact is a wrapper around CoffeeScript that introduces JSX. I
would like to convert my CJSX files to fancy ES2015 too!

As the CoffeeReact still uses the same version of CoffeeScript I figured
this change wouldn't do any harm
